### PR TITLE
[feature/#138] 이벤트탭+ 티켓 API 연동

### DIFF
--- a/src/app/(fullscreen)/event/ticket/_components/card-back.tsx
+++ b/src/app/(fullscreen)/event/ticket/_components/card-back.tsx
@@ -1,44 +1,57 @@
 import { LogoWhiteIcon } from "@/icons/index";
+
 import { Fragment } from "react";
 
-const cardInfo = [
-  { label: "위치", value: "서울특별시 어쩌구 저쩌구 무슨로" },
-  { label: "일시", value: "2025. 05. 26 (일)" },
-  { label: "시간", value: "18:00~20:24" },
-  { label: "인원", value: "모집인원 24명", isSectionStart: true },
-  { label: "가격", value: "24,000원" },
-  { label: "주최", value: "김서현" },
-];
+export default function CardBack({ ticket }: { ticket: any }) {
+  const cardInfo = [
+    { label: "위치", value: ticket?.address },
+    { label: "일시", value: ticket?.scheduledAt },
+    { label: "시간", value: ticket?.time },
+    { label: "인원", value: ticket?.participants, isSectionStart: true },
+    { label: "가격", value: ticket?.price },
+    { label: "주최", value: ticket?.hostName },
+  ];
 
-export default function CardBack() {
   return (
     <div className="card-shadow-blur absolute h-full w-full rotate-y-180 overflow-hidden rounded-[20px] bg-white/30 px-3.5 pb-4 backface-hidden">
-      <h2 className="title-3-bold mt-17.25">빌리 엘리어트</h2>
+      <h2 className="title-3-bold mt-17.25">{ticket?.title}</h2>
       <h3 className="caption-1-medium mt-0.5 text-gray-200">
-        (영화) 신촌 아트레온
+        ({ticket?.type}) {ticket?.location}
       </h3>
 
       <div className="bg-gray-white mt-2.25 h-0.25 w-full opacity-14" />
 
       <div className="mt-5 grid grid-cols-[auto_1fr] gap-x-4.5 gap-y-2">
-        {cardInfo.map(({ label, value, isSectionStart }) => (
-          <Fragment key={label}>
-            <p
-              className={`caption-1-medium text-gray-200 ${
-                isSectionStart ? "mt-3" : ""
-              }`}
-            >
-              {label}
-            </p>
-            <p
-              className={`caption-1-regular text-gray-100 ${
-                isSectionStart ? "mt-3" : ""
-              }`}
-            >
-              {value}
-            </p>
-          </Fragment>
-        ))}
+        {cardInfo.map(({ label, value, isSectionStart }) => {
+          let displayValue = value;
+
+          if (label === "가격" && typeof value === "number") {
+            displayValue = `${value.toLocaleString()}원`;
+          }
+
+          if (label === "인원" && typeof value === "number") {
+            displayValue = `모집인원 ${value}명`;
+          }
+
+          return (
+            <Fragment key={label}>
+              <p
+                className={`caption-1-medium text-gray-200 ${
+                  isSectionStart ? "mt-3" : ""
+                }`}
+              >
+                {label}
+              </p>
+              <p
+                className={`caption-1-regular text-gray-100 ${
+                  isSectionStart ? "mt-3" : ""
+                }`}
+              >
+                {displayValue}
+              </p>
+            </Fragment>
+          );
+        })}
       </div>
 
       <LogoWhiteIcon

--- a/src/app/(fullscreen)/event/ticket/_components/card-front.tsx
+++ b/src/app/(fullscreen)/event/ticket/_components/card-front.tsx
@@ -1,33 +1,38 @@
-import { PATH_IMAGES } from "@/constants/path-images";
 import { LogoWhiteIcon } from "@/icons/index";
 import Image from "next/image";
-import { Fragment } from "react";
 
-const infoData = [
-  { label: "일시", value: "2025. 05. 26" },
-  { label: "장소", value: "신촌 아트레온" },
-  { label: "예상 금액", value: "24,000원" },
-];
+export default function CardFront({ ticket }: { ticket: any }) {
+  const infoData = [
+    { label: "일시", value: ticket?.scheduledAt },
+    { label: "장소", value: ticket?.location },
+    { label: "예상 금액", value: ticket?.price },
+  ];
 
-export default function CardFront() {
   return (
     <div className="card-shadow-blur absolute h-full w-full overflow-hidden rounded-[20px] bg-white/30 p-3 backface-hidden">
       <div className="relative h-66.25 w-66.25 overflow-hidden">
         <Image
-          src={PATH_IMAGES.IMAGE}
+          src={ticket?.eventImageUrl}
           fill
           alt="ticket-image"
           className="rounded-lg object-cover"
         />
       </div>
-      <p className="title-3-bold mt-5 pl-0.5">빌리 엘리어트</p>
+      <p className="title-3-bold mt-5 pl-0.5">{ticket?.title}</p>
       <div className="mt-2.5 grid grid-cols-3 gap-x-6 gap-y-1.5 pl-0.5">
-        {infoData.map(({ label, value }) => (
-          <div key={label} className="flex flex-col items-start">
-            <h2 className="caption-3-medium opacity-48">{label}</h2>
-            <p className="caption-1-medium opacity-48">{value}</p>
-          </div>
-        ))}
+        {infoData.map(({ label, value }) => {
+          const displayValue =
+            label === "예상 금액" && typeof value === "number"
+              ? `${value.toLocaleString()}원`
+              : value;
+
+          return (
+            <div key={label} className="flex flex-col items-start">
+              <h2 className="caption-3-medium opacity-48">{label}</h2>
+              <p className="caption-1-medium opacity-48">{displayValue}</p>
+            </div>
+          );
+        })}
       </div>
 
       <LogoWhiteIcon

--- a/src/app/(fullscreen)/event/ticket/_components/client.tsx
+++ b/src/app/(fullscreen)/event/ticket/_components/client.tsx
@@ -1,12 +1,23 @@
 "use client";
 
-import { useState } from "react";
-import CardBack from "./card-back";
-import CardFront from "./card-front";
-import { RotateIcon } from "@/icons/index";
+import { useSearchParams } from "next/navigation";
 
-export default function Client() {
+import CardFront from "./card-front";
+import CardBack from "./card-back";
+import { RotateIcon } from "@/icons/index";
+import { useState } from "react";
+import Loading from "app/loading";
+import { useTicketDetail } from "app/_hooks/events/use-ticket-detail";
+
+export default function TicketPage() {
+  const searchParams = useSearchParams();
+  const ticketId = searchParams.get("id");
+  const { data: ticket, isLoading } = useTicketDetail(ticketId);
   const [flipped, setFlipped] = useState(false);
+
+  if (isLoading) return <Loading />;
+  if (!ticket)
+    return <p className="text-center text-white">티켓이 없습니다.</p>;
 
   return (
     <div className="flex h-full flex-col items-center justify-center gap-8.5">
@@ -16,8 +27,8 @@ export default function Client() {
           flipped ? "rotate-y-180" : ""
         }`}
       >
-        <CardFront />
-        <CardBack />
+        <CardFront ticket={ticket} />
+        <CardBack ticket={ticket} />
       </div>
       <button
         type="button"

--- a/src/app/(tabs)/event/_components/event-tabs.tsx
+++ b/src/app/(tabs)/event/_components/event-tabs.tsx
@@ -2,11 +2,12 @@
 
 import { ToggleTab, Card } from "@/components";
 import { EmptyIcon } from "@/icons/index";
-import { mapEventCardToCardProps } from "@/utils/map-to-eventcard";
+
 import { useEventTabQuery } from "app/_hooks/events/use-event-tab-query";
 
 interface EventTabProps {
   type: "신청 목록" | "내 이벤트";
+  statusMap: Record<string, string[]>;
 }
 
 const TOGGLES = { "모집 이벤트": 0, "확정 이벤트": 1 } as const;
@@ -20,10 +21,7 @@ export default function EventTab({ type }: EventTabProps) {
   } = useEventTabQuery(type);
 
   if (isError) {
-    return (
-      <p className="text-center">이벤트를 불러오지 못했습니다.</p>
-      //TODO: 에러 처리
-    );
+    return <p className="text-center">이벤트를 불러오지 못했습니다.</p>;
   }
 
   return (
@@ -40,7 +38,21 @@ export default function EventTab({ type }: EventTabProps) {
         {events.length > 0 ? (
           events.map((event, index) => (
             <div key={event.eventId}>
-              <Card {...mapEventCardToCardProps(event)} />
+              <Card
+                imageUrl={event.posterImageUrl}
+                category={event.mediaType}
+                title={event.mediaTitle}
+                placeAndDate={`${event.locationName} · ${event.eventDate}`}
+                description={event.description}
+                ddayBadge={
+                  event.d_day !== null ? `D-${event.d_day}` : undefined
+                }
+                statusBadge={event.eventStatus}
+                progressRate={
+                  event.rate !== undefined ? `${event.rate}%` : undefined
+                }
+                estimatedPrice={event.estimatedPrice}
+              />
               {index < events.length - 1 && (
                 <div className="my-4 h-px w-full bg-gray-950" />
               )}

--- a/src/app/(tabs)/event/_components/ticket-card.tsx
+++ b/src/app/(tabs)/event/_components/ticket-card.tsx
@@ -2,8 +2,10 @@
 
 import { CardProps } from "app/_types/card";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 
 export function Card({
+  id,
   imageUrl,
   title,
   placeAndDate,
@@ -13,8 +15,16 @@ export function Card({
   progressRate,
   estimatedPrice,
 }: CardProps) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push(`/event/ticket?id=${id}`);
+  };
   return (
-    <div className="relative flex flex-col overflow-hidden rounded-xl bg-gray-950">
+    <div
+      onClick={handleClick}
+      className="relative flex flex-col overflow-hidden rounded-xl bg-gray-950"
+    >
       <div className="relative h-41.75 w-full overflow-hidden">
         <Image src={imageUrl} alt={title} fill className="object-cover" />
         {(ddayBadge || statusBadge) && (

--- a/src/app/(tabs)/event/_components/ticket-tab.tsx
+++ b/src/app/(tabs)/event/_components/ticket-tab.tsx
@@ -2,21 +2,32 @@
 
 import { Card } from "./ticket-card";
 import { EmptyTicketIcon } from "@/icons/index";
-import { MOCK_DATA } from "@/mocks/mock-data";
-import { mapEventCardToCardProps } from "@/utils/map-to-eventcard";
+import { useTickets } from "app/_hooks/events/use-ticket";
+import Loading from "app/loading";
 
 export default function TicketTab() {
-  const filteredEvents = MOCK_DATA.filter((event) =>
-    ["대관확정", "상영완료"].includes(event.statusBadge),
-  );
+  const { data: tickets = [], isLoading } = useTickets();
+
+  if (isLoading) {
+    return <Loading />;
+  }
 
   return (
     <div className="pb-24">
       <div className="mt-6 flex flex-col gap-5">
-        {filteredEvents.length > 0 ? (
-          filteredEvents.map((event, index) => (
-            <div key={index}>
-              <Card {...mapEventCardToCardProps(event)} />
+        {tickets.length > 0 ? (
+          tickets.map((ticket) => (
+            <div key={ticket.ticketId}>
+              <Card
+                id={ticket.ticketId}
+                imageUrl={ticket.eventImageUrl}
+                title={ticket.title}
+                placeAndDate={`${ticket.location} · ${ticket.scheduledAt}`}
+                description={ticket.description}
+                ddayBadge={null}
+                progressRate={undefined}
+                estimatedPrice={undefined}
+              />
             </div>
           ))
         ) : (

--- a/src/app/_apis/events/detail-ticket.ts
+++ b/src/app/_apis/events/detail-ticket.ts
@@ -1,0 +1,5 @@
+import { apiGet } from "../methods";
+
+export const fetchTickets = (page = 0, size = 10) => {
+  return apiGet<any[]>("/tickets", { page, size });
+};

--- a/src/app/_components/main-card.tsx
+++ b/src/app/_components/main-card.tsx
@@ -14,7 +14,7 @@ interface CardProps {
   ddayBadge?: string | null;
   statusBadge?: string;
   progressRate?: string;
-  estimatedPrice?: string;
+  estimatedPrice?: string | number;
 }
 
 export default function Card({
@@ -37,8 +37,8 @@ export default function Card({
     >
       <div className="relative h-30 w-30 overflow-hidden rounded-md">
         <Image
-          src={imageUrl}
-          alt="포스터 이미지"
+          src={imageUrl || "/images/default-image.png"}
+          alt={title}
           fill
           className="object-cover"
         />

--- a/src/app/_hooks/events/use-ticket-detail.ts
+++ b/src/app/_hooks/events/use-ticket-detail.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiGet } from "app/_apis/methods";
+
+export const useTicketDetail = (ticketId: string | null) => {
+  return useQuery({
+    queryKey: ["ticket", ticketId],
+    queryFn: () => apiGet(`/tickets/${ticketId}`),
+    enabled: !!ticketId,
+  });
+};

--- a/src/app/_hooks/events/use-ticket.ts
+++ b/src/app/_hooks/events/use-ticket.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchTickets } from "app/_apis/events/detail-ticket";
+
+export const useTickets = (page = 0, size = 10) => {
+  return useQuery({
+    queryKey: ["tickets", page, size],
+    queryFn: () => fetchTickets(page, size),
+  });
+};

--- a/src/app/_types/card.ts
+++ b/src/app/_types/card.ts
@@ -12,7 +12,7 @@ export interface EventCard {
   posterImageUrl: string;
 }
 export interface CardProps {
-  id?: string;
+  id?: string | number;
   imageUrl: string;
   category?: string;
   title: string;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #

---
## 📋 작업 상세 내용
- 브랜치 바꾸다가 인지,,, 깃이 끊겨있어서 dev에 반영안된것 같습니다
- 이벤트탭+ 티켓 조회 api 연동 부분 다시 작성해서 확인했습니다.

---

## 📸 스크린샷 (선택)

<!--UI/스타일 변경이 있다면, 전/후 비교 스크린샷 또는 데모 GIF 첨부-->
![image](https://github.com/user-attachments/assets/1792adc0-227a-4b80-b722-488331d260a8)


## 📌 앞으로의 작업 (선택)

<!--이 PR 이후로 진행해야 할 작업, 남은 TODO 등을 적어주세요.-->


## 💬 리뷰 요구사항 / 의논사항 / 레퍼런스 (선택)

<!--추가적으로 의논사항, 레퍼런스 링크 , 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요-->
