### PR TITLE
[Bug/#383] 줄바꿈 문제 수정 및 스크롤 스타일 수정

### DIFF
--- a/src/app/_components/detail-content.tsx
+++ b/src/app/_components/detail-content.tsx
@@ -113,7 +113,7 @@ export default function DetailContent({ ...props }) {
           <p className="body-1-semibold mt-3 text-gray-200">
             {props.eventTitle || "이벤트 제목"}
           </p>
-          <p className="body-3-regular mt-2 text-gray-400">
+          <p className="body-3-regular mt-2 whitespace-pre-wrap text-gray-400">
             {props.description || "이벤트 설명"}
           </p>
 

--- a/src/app/_styles/base.css
+++ b/src/app/_styles/base.css
@@ -81,21 +81,6 @@ input:-webkit-autofill {
 input {
   caret-color: white;
 }
-/* 스크롤바 스타일 */
-::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-::-webkit-scrollbar-thumb {
-  background-color: rgba(100, 100, 100, 0.6);
-  border-radius: 4px;
-}
-::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(100, 100, 100, 0.8);
-}
 
 .app-header {
   padding-top: var(--safe-top);

--- a/src/app/_styles/base.css
+++ b/src/app/_styles/base.css
@@ -21,6 +21,14 @@ button {
   cursor: pointer;
 }
 
+* {
+  -ms-overflow-style: none; /* IE/Edge 레거시 */
+  scrollbar-width: none; /* Firefox */
+}
+*::-webkit-scrollbar {
+  display: none; /* Chrome/Safari */
+}
+
 :root {
   --app-max: 500px;
   --safe-top: env(safe-area-inset-top);


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

어떤 변경 사항이 있나요?

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #383 

---
## 📋 작업 상세 내용

### 1) 스크롤바 숨김 처리

<table>
  <tr>
    <td valign="top" style="padding-right: 8px;">
      <img width="494" alt="스크린샷 1" src="https://github.com/user-attachments/assets/b0ffb503-234d-4366-9308-46470db3fd11" />
    </td>
    <td valign="top" style="padding-left: 8px;">
      <img width="482" alt="스크린샷 2" src="https://github.com/user-attachments/assets/8230ccb6-613b-434b-8826-dddeb10e4d7e" />
    </td>
  </tr>
</table>


디자인 상 스크롤바 노출을 제거하기 위해 styles/base.css에 전역 스타일을 추가했습니다.

```tsx
* {
  -ms-overflow-style: none; /* IE/Edge 레거시 */
  scrollbar-width: none; /* Firefox */
}
*::-webkit-scrollbar {
  display: none; /* Chrome/Safari */
}
```
- 스크롤은 유지하되(기능은 그대로), 스크롤바 UI만 숨깁니다.

- 전역 적용이므로 혹시 스크롤바가 필요한 페이지/영역이 있다면 추후 범위를 컨테이너 단위로 조정할 수 있습니다.

### 2) description 줄바꿈(\n) 렌더링 반영

서버에서 description이 \n 포함 문자열로 내려오지만 줄바꿈이 렌더링되지 않아, 텍스트 영역에 whitespace-pre-wrap를 적용했습니다.

- \n 개행을 화면에 그대로 반영

- 문단/공백을 유지하면서 자동 줄바꿈도 동작

<table>
  <tr>
    <td align="center" valign="top" style="padding-right: 8px;">
      <b>Before</b><br />
      <img width="492" alt="Before - description 줄바꿈 미적용" src="https://github.com/user-attachments/assets/1676f6b0-c2e2-4383-8076-4fbd105df159" />
    </td>
    <td align="center" valign="top" style="padding-left: 8px;">
      <b>After</b><br />
      <img width="495" alt="After - description 줄바꿈 적용" src="https://github.com/user-attachments/assets/e15a4971-aa67-4c05-9320-4b0d56adaee8" />
    </td>
  </tr>
</table>


