### PR TITLE
[Bug/#389] 캘린더 날짜 선택 및 무한 렌더링 오류 수정 및 기존 로직 복구

### DIFF
--- a/src/app/(fullscreen)/event-create/components/calendar.tsx
+++ b/src/app/(fullscreen)/event-create/components/calendar.tsx
@@ -10,16 +10,15 @@ interface CalendarProps {
   selectedDate: string | null;
   onSelectDate: (date: string) => void;
 }
-//TODO: 테스트를 위한 기존코드 주석 처리
 
 const Calendar = ({ selectedDate, onSelectDate }: CalendarProps) => {
   const today = dayjs().startOf("day");
-  // FIX: const fourWeeksLater = today.add(4, "week");
+  const fourWeeksLater = today.add(4, "week");
   const [showToast, setShowToast] = useState(false);
 
-  const [currentMonth, setCurrentMonth] = useState(dayjs().startOf("month"));
-  // FIX: const [currentMonth, setCurrentMonth] = useState(
-  // FIX:   dayjs().add(4, "week").startOf("month"), );
+  const [currentMonth, setCurrentMonth] = useState(
+    dayjs().add(4, "week").startOf("month"),
+  );
 
   const startDay = currentMonth.startOf("month").day();
   const daysInMonth = currentMonth.daysInMonth();
@@ -28,8 +27,7 @@ const Calendar = ({ selectedDate, onSelectDate }: CalendarProps) => {
   );
 
   const handleSelect = (date: dayjs.Dayjs) => {
-    if (date.isAfter(today.subtract(1, "day"))) {
-      //FIX:  if (date.isAfter(fourWeeksLater.subtract(1, "day"))) {
+    if (date.isAfter(fourWeeksLater.subtract(1, "day"))) {
       onSelectDate(date.format("YYYY-MM-DD"));
     } else {
       setShowToast(true);
@@ -55,7 +53,7 @@ const Calendar = ({ selectedDate, onSelectDate }: CalendarProps) => {
   const isPrevDisabled = currentMonth.isSame(today, "month");
 
   return (
-    <div className="relative mx-auto w-[335px] rounded-[10px] bg-gray-950 px-7.5 pt-5 pb-8 text-white">
+    <div className="relative mx-auto w-83.75 rounded-[10px] bg-gray-950 px-7.5 pt-5 pb-8 text-white">
       {showToast && (
         <div className="fixed bottom-32 left-1/2 z-50 -translate-x-1/2">
           <Toast iconType="alert">오늘 이후 날짜만 선택 가능해요</Toast>
@@ -98,8 +96,7 @@ const Calendar = ({ selectedDate, onSelectDate }: CalendarProps) => {
 
         {dates.map((date) => {
           const isToday = date.isSame(today, "day");
-          // FIX: const isSelectable = date.isAfter(fourWeeksLater.subtract(1, "day"));
-          const isSelectable = date.isAfter(today.subtract(1, "day"));
+          const isSelectable = date.isAfter(fourWeeksLater.subtract(1, "day"));
           const isSelected = selectedDate === date.format("YYYY-MM-DD");
 
           return (

--- a/src/app/(fullscreen)/event-create/components/period-calendar.tsx
+++ b/src/app/(fullscreen)/event-create/components/period-calendar.tsx
@@ -26,10 +26,9 @@ const DeadlineCalendar = ({
   selectedDeadline,
   onSelectDeadline,
 }: DeadlineCalendarProps) => {
-  const today = dayjs().startOf("day");
-  const event = dayjs(eventDate);
-  // FIX: const latestDeadline = event.subtract(2, "week");
-  const latestDeadline = event;
+  const today = useMemo(() => dayjs().startOf("day"), []);
+  const event = useMemo(() => dayjs(eventDate), [eventDate]);
+  const latestDeadline = event.subtract(2, "week");
 
   const [currentMonth, setCurrentMonth] = useState(() =>
     selectedDeadline ? dayjs(selectedDeadline).startOf("month") : dayjs(),
@@ -79,7 +78,7 @@ const DeadlineCalendar = ({
   }, [selectedDeadline, currentMonth, today]);
 
   return (
-    <div className="relative mx-auto w-[335px] rounded-[10px] bg-gray-950 px-7.5 pt-5 pb-8 text-white">
+    <div className="relative mx-auto w-83.75 rounded-[10px] bg-gray-950 px-7.5 pt-5 pb-8 text-white">
       {showToast && (
         <div className="fixed bottom-32 left-1/2 z-50 -translate-x-1/2">
           <Toast iconType="alert">


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

캘린더 날짜 선택 및 무한 렌더링 오류 수정 및 기존 로직 복구

## #️⃣ 연관된 이슈

<!-- close #123 -->

close #389

---
## 📋 작업 상세 내용

### 1. 캘린더 날짜 선택 로직 복구

테스트를 위해 임시로 변경했던 캘린더 날짜 선택 기준을 기존 로직으로 복구했습니다.

- 주석 처리되어 있던 기존 날짜 기준 로직 복구
- 테스트용으로 임시 적용했던 날짜 조건 제거


### 2. 캘린더 렌더링 오류 수정

캘린더에서 `Maximum update depth exceeded` 오류가 발생하던 부분을 수정했습니다.

렌더링마다 새로 생성되는 `dayjs` 객체가 `useEffect` 의존성으로 사용되면서 불필요한 상태 업데이트가 반복될 수 있어, `useMemo`를 사용해 기준 날짜 값을 안정적으로 관리하도록 수정했습니다.

---

