### PR TITLE
[Refactor/#394] 홈 화면 LCP 후보 이미지 로딩 경로 개선

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,6 @@ jobs:
         run: pnpm install
 
       - name: 🛠 Run build
+        env:
+          API_BASE_URL: ${{ secrets.API_BASE_URL }}
         run: pnpm build

--- a/src/app/(fullscreen)/category/[category]/client.tsx
+++ b/src/app/(fullscreen)/category/[category]/client.tsx
@@ -57,6 +57,7 @@ export default function CategoryPageClient({ label }: { label: string }) {
                   statusBadge={card.eventStatus}
                   progressRate={`${card.rate}%`}
                   estimatedPrice={card.estimatedPrice}
+                  imagePriority={idx == 0}
                 />
                 {idx < cards.length - 1 && (
                   <div className="bg-border my-4 h-px w-full" />

--- a/src/app/(fullscreen)/search/page.tsx
+++ b/src/app/(fullscreen)/search/page.tsx
@@ -77,7 +77,7 @@ export default function Search() {
         <>
           <div className="mt-6 flex flex-1 flex-col gap-8 px-5">
             {cards.length > 0 ? (
-              cards.map((card) => (
+              cards.map((card, index) => (
                 <Card
                   key={String(card.eventId)}
                   id={String(card.eventId)}
@@ -90,6 +90,7 @@ export default function Search() {
                   statusBadge={card.eventStatus}
                   progressRate={`${card.rate}%`}
                   estimatedPrice={card.estimatedPrice}
+                  imagePriority={index === 0}
                 />
               ))
             ) : (

--- a/src/app/(tabs)/home/_components/discover.tsx
+++ b/src/app/(tabs)/home/_components/discover.tsx
@@ -78,7 +78,7 @@ export default function Discover() {
         }
       >
         <>
-          {events.slice(0, 5).map((event) => (
+          {events.slice(0, 5).map((event, index) => (
             <div key={event.eventId}>
               <Card
                 id={String(event.eventId)}
@@ -91,6 +91,7 @@ export default function Discover() {
                 statusBadge={event.eventStatus}
                 progressRate={`${event.rate}%`}
                 estimatedPrice={String(event.estimatedPrice)}
+                imagePriority={index === 0}
               />
               <div className="my-4 h-px w-full bg-gray-950" />
             </div>

--- a/src/app/(tabs)/home/_utils/category-events.ts
+++ b/src/app/(tabs)/home/_utils/category-events.ts
@@ -9,9 +9,8 @@ export const prefetchHomeCategoryEvents = async (
   queryClient: QueryClient,
   category: string,
 ) => {
-  const cookieHeader = await getForwardedCookieHeader();
-
   try {
+    const cookieHeader = await getForwardedCookieHeader();
     await queryClient.prefetchQuery(
       categoryEventsQueryOptions(
         category,
@@ -25,6 +24,7 @@ export const prefetchHomeCategoryEvents = async (
       ),
     );
   } catch (error) {
-    console.error("홈 카테고리 이벤트 prefetch 실패:", error);
+    const message = error instanceof Error ? error.message : "unknown error";
+    console.error("홈 카테고리 이벤트 prefetch 실패", { category, message });
   }
 };

--- a/src/app/(tabs)/home/_utils/category-events.ts
+++ b/src/app/(tabs)/home/_utils/category-events.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import type { QueryClient } from "@tanstack/react-query";
+
+import { categoryEventsQueryOptions } from "app/_hooks/events/use-category-events";
+import { getForwardedCookieHeader } from "app/_apis/server-cookie";
+
+export const prefetchHomeCategoryEvents = async (
+  queryClient: QueryClient,
+  category: string,
+) => {
+  const cookieHeader = await getForwardedCookieHeader();
+
+  try {
+    await queryClient.prefetchQuery(
+      categoryEventsQueryOptions(
+        category,
+        cookieHeader
+          ? {
+              headers: {
+                Cookie: cookieHeader,
+              },
+            }
+          : undefined,
+      ),
+    );
+  } catch (error) {
+    console.error("홈 카테고리 이벤트 prefetch 실패:", error);
+  }
+};

--- a/src/app/(tabs)/home/client.tsx
+++ b/src/app/(tabs)/home/client.tsx
@@ -25,11 +25,9 @@ export default function Client() {
   const router = useRouter();
   useHomeSideEffects();
 
-  const hasHydrated = useHomeUIStore((s) => s.hasHydrated);
-  const activeTab = useHomeUIStore((s) => s.activeTab);
   const setActiveTab = useHomeUIStore((s) => s.setActiveTab);
 
-  const currentTab = hasHydrated ? activeTab : "discover";
+  const currentTab = useHomeUIStore((s) => s.activeTab);
 
   const handleSearch = () => {
     router.push(PATHS.SEARCH);

--- a/src/app/(tabs)/home/client.tsx
+++ b/src/app/(tabs)/home/client.tsx
@@ -36,7 +36,7 @@ export default function Client() {
   };
 
   return (
-    <div className="h-[calc(100dvh-102px)]">
+    <>
       <div className="flex justify-between px-5 pt-5.75">
         <nav aria-label="홈 탭" className="flex gap-3">
           {HOME_TABS.map((tab) => {
@@ -71,6 +71,6 @@ export default function Client() {
       </div>
 
       <EventCreateButton />
-    </div>
+    </>
   );
 }

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -3,31 +3,15 @@ import {
   HydrationBoundary,
   QueryClient,
 } from "@tanstack/react-query";
-import { cookies } from "next/headers";
 
 import Client from "./client";
-import { categoryEventsQueryOptions } from "app/_hooks/events/use-category-events";
+import { prefetchHomeCategoryEvents } from "./_utils/category-events";
 
 const DEFAULT_HOME_CATEGORY = "인기";
 
 export default async function Home() {
   const queryClient = new QueryClient();
-
-  const cookieStore = await cookies();
-  const cookieHeader = cookieStore.toString();
-
-  await queryClient.prefetchQuery(
-    categoryEventsQueryOptions(
-      DEFAULT_HOME_CATEGORY,
-      cookieHeader
-        ? {
-            headers: {
-              Cookie: cookieHeader,
-            },
-          }
-        : undefined,
-    ),
-  );
+  await prefetchHomeCategoryEvents(queryClient, DEFAULT_HOME_CATEGORY);
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -1,5 +1,25 @@
-import Client from "app/(tabs)/home/client";
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from "@tanstack/react-query";
 
-export default function Home() {
-  return <Client />;
+import Client from "./client";
+import { categoryEventsQueryOptions } from "app/_hooks/events/use-category-events";
+
+export default async function Home() {
+  const DEFAULT_HOME_CATEGORY = "인기";
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery(
+    categoryEventsQueryOptions(DEFAULT_HOME_CATEGORY),
+  );
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <div className="h-[calc(100dvh-102px)]">
+        <Client />
+      </div>
+    </HydrationBoundary>
+  );
 }

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -3,16 +3,30 @@ import {
   HydrationBoundary,
   QueryClient,
 } from "@tanstack/react-query";
+import { cookies } from "next/headers";
 
 import Client from "./client";
 import { categoryEventsQueryOptions } from "app/_hooks/events/use-category-events";
 
+const DEFAULT_HOME_CATEGORY = "인기";
+
 export default async function Home() {
-  const DEFAULT_HOME_CATEGORY = "인기";
   const queryClient = new QueryClient();
 
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.toString();
+
   await queryClient.prefetchQuery(
-    categoryEventsQueryOptions(DEFAULT_HOME_CATEGORY),
+    categoryEventsQueryOptions(
+      DEFAULT_HOME_CATEGORY,
+      cookieHeader
+        ? {
+            headers: {
+              Cookie: cookieHeader,
+            },
+          }
+        : undefined,
+    ),
   );
 
   return (

--- a/src/app/_apis/events/category.ts
+++ b/src/app/_apis/events/category.ts
@@ -1,4 +1,5 @@
 import { EventCard } from "app/_types/card";
+import { AxiosRequestConfig } from "axios";
 import { apiGet } from "../methods";
 import { devError } from "@/utils/dev-logger";
 
@@ -10,13 +11,18 @@ export const getEventsByCategory = async (
   category: string,
   page = 0,
   size = 10,
+  config?: AxiosRequestConfig,
 ): Promise<CategoryEventsResult> => {
   try {
-    const res = await apiGet<CategoryEventsResult>("/events/category", {
-      category,
-      page,
-      size,
-    });
+    const res = await apiGet<CategoryEventsResult>(
+      "/events/category",
+      {
+        category,
+        page,
+        size,
+      },
+      config,
+    );
 
     return {
       totalPages: res.totalPages ?? 0,

--- a/src/app/_apis/instance.ts
+++ b/src/app/_apis/instance.ts
@@ -18,8 +18,12 @@ const API_ORIGIN = process.env.NEXT_PUBLIC_BASE_URL;
 
 const isServer = typeof window === "undefined";
 
+if (isServer && !API_ORIGIN) {
+  throw new Error("NEXT_PUBLIC_BASE_URL is required in server runtime");
+}
+
 const axiosInstance: AxiosInstance = axios.create({
-  baseURL: isServer ? `${API_ORIGIN}/api` : "/api",
+  baseURL: isServer ? new URL("/api", API_ORIGIN!).toString() : "/api",
   withCredentials: true,
 });
 

--- a/src/app/_apis/instance.ts
+++ b/src/app/_apis/instance.ts
@@ -10,8 +10,16 @@ import { toNormalizedEndpoint } from "@/lib/sentry-event-filter";
 type RetryableRequestConfig = InternalAxiosRequestConfig & { _retry?: boolean };
 type CapturableError = AxiosError & { __sentryCaptured?: boolean };
 
+const STAGE =
+  process.env.NEXT_PUBLIC_STAGE ??
+  (process.env.VERCEL_ENV === "production" ? "prod" : "dev");
+
+const API_ORIGIN = process.env.NEXT_PUBLIC_BASE_URL;
+
+const isServer = typeof window === "undefined";
+
 const axiosInstance: AxiosInstance = axios.create({
-  baseURL: "/api",
+  baseURL: isServer ? `${API_ORIGIN}/api` : "/api",
   withCredentials: true,
 });
 
@@ -30,7 +38,8 @@ axiosInstance.interceptors.response.use(
     const normalizedPath = toNormalizedEndpoint(originalRequest?.url);
 
     if (
-      error.response?.status === 401 &&
+      typeof window !== "undefined" &&
+      status === 401 &&
       originalRequest &&
       !originalRequest._retry
     ) {
@@ -43,6 +52,7 @@ axiosInstance.interceptors.response.use(
         return axiosInstance(originalRequest);
       } catch (refreshError) {
         window.location.href = PATHS.LOGIN;
+        return Promise.reject(refreshError);
       }
     }
 

--- a/src/app/_apis/instance.ts
+++ b/src/app/_apis/instance.ts
@@ -14,7 +14,7 @@ const STAGE =
   process.env.NEXT_PUBLIC_STAGE ??
   (process.env.VERCEL_ENV === "production" ? "prod" : "dev");
 
-const API_ORIGIN = process.env.NEXT_PUBLIC_BASE_URL;
+const API_ORIGIN = process.env.NEXT_PUBLIC_VERCEL;
 
 const isServer = typeof window === "undefined";
 

--- a/src/app/_apis/instance.ts
+++ b/src/app/_apis/instance.ts
@@ -18,10 +18,6 @@ const API_ORIGIN = process.env.NEXT_PUBLIC_VERCEL;
 
 const isServer = typeof window === "undefined";
 
-if (isServer && !API_ORIGIN) {
-  throw new Error("NEXT_PUBLIC_BASE_URL is required in server runtime");
-}
-
 const axiosInstance: AxiosInstance = axios.create({
   baseURL: isServer ? new URL("/api", API_ORIGIN!).toString() : "/api",
   withCredentials: true,

--- a/src/app/_apis/instance.ts
+++ b/src/app/_apis/instance.ts
@@ -10,13 +10,16 @@ import { toNormalizedEndpoint } from "@/lib/sentry-event-filter";
 type RetryableRequestConfig = InternalAxiosRequestConfig & { _retry?: boolean };
 type CapturableError = AxiosError & { __sentryCaptured?: boolean };
 
-const STAGE =
-  process.env.NEXT_PUBLIC_STAGE ??
-  (process.env.VERCEL_ENV === "production" ? "prod" : "dev");
-
-const API_ORIGIN = process.env.NEXT_PUBLIC_VERCEL;
-
 const isServer = typeof window === "undefined";
+
+const API_ORIGIN =
+  process.env.API_BASE_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  process.env.NEXT_PUBLIC_BASE_URL;
+
+if (isServer && !API_ORIGIN) {
+  throw new Error("NEXT_PUBLIC_BASE_URL is required in server runtime");
+}
 
 const axiosInstance: AxiosInstance = axios.create({
   baseURL: isServer ? new URL("/api", API_ORIGIN!).toString() : "/api",

--- a/src/app/_apis/methods.ts
+++ b/src/app/_apis/methods.ts
@@ -5,8 +5,12 @@ import { ApiResponse } from "./type";
 export const apiGet = async <T, P = Record<string, any>>(
   url: string,
   params?: P,
+  config?: AxiosRequestConfig,
 ): Promise<T> => {
-  const response = await axiosInstance.get<ApiResponse<T>>(url, { params });
+  const response = await axiosInstance.get<ApiResponse<T>>(url, {
+    ...config,
+    params,
+  });
   return response.data.result;
 };
 

--- a/src/app/_apis/server-cookie.ts
+++ b/src/app/_apis/server-cookie.ts
@@ -1,0 +1,20 @@
+import "server-only";
+
+import { cookies } from "next/headers";
+
+const DEFAULT_FORWARDED_COOKIE_NAMES = ["accessToken"] as const;
+
+export const getForwardedCookieHeader = async (
+  cookieNames: readonly string[] = DEFAULT_FORWARDED_COOKIE_NAMES,
+) => {
+  const cookieStore = await cookies();
+
+  return cookieNames
+    .map((name) => {
+      const value = cookieStore.get(name)?.value;
+
+      return value ? `${name}=${value}` : null;
+    })
+    .filter((value): value is string => Boolean(value))
+    .join("; ");
+};

--- a/src/app/_components/main-card.tsx
+++ b/src/app/_components/main-card.tsx
@@ -15,6 +15,7 @@ function Card({
   ddayBadge,
   statusBadge,
   estimatedPrice,
+  imagePriority,
   query = {},
 }: CardProps) {
   const router = useRouter();
@@ -36,7 +37,8 @@ function Card({
           src={imageUrl || "/images/default-image.png"}
           alt={title}
           fill
-          loading="eager"
+          loading={imagePriority ? "eager" : "lazy"}
+          fetchPriority={imagePriority ? "high" : "auto"}
           className="object-cover"
           sizes="120px"
         />

--- a/src/app/_hooks/events/use-category-events.ts
+++ b/src/app/_hooks/events/use-category-events.ts
@@ -1,6 +1,16 @@
-import { useQuery } from "@tanstack/react-query";
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import type { AxiosRequestConfig } from "axios";
 import { getEventsByCategory } from "app/_apis/events/category";
-import { queryOptions } from "@tanstack/react-query";
+
+export const categoryEventsQueryOptions = (
+  category: string,
+  config?: AxiosRequestConfig,
+) =>
+  queryOptions({
+    queryKey: ["category-events", category],
+    queryFn: () => getEventsByCategory(category, 0, 10, config),
+    staleTime: 1000 * 60,
+  });
 
 export const useCategoryEvents = (
   category: string,
@@ -9,19 +19,10 @@ export const useCategoryEvents = (
   },
 ) => {
   return useQuery({
-    queryKey: ["category-events", category],
-    queryFn: () => getEventsByCategory(category),
-    staleTime: 1000 * 60, // optional
+    ...categoryEventsQueryOptions(category),
     ...options, // enabled 등 외부 옵션 허용
   });
 };
-
-export const categoryEventsQueryOptions = (category: string) =>
-  queryOptions({
-    queryKey: ["category-events-home", category],
-    queryFn: () => getEventsByCategory(category),
-    staleTime: 1000 * 60,
-  });
 
 export const useCategoryPageEvents = (
   category: string,

--- a/src/app/_hooks/events/use-category-events.ts
+++ b/src/app/_hooks/events/use-category-events.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { getEventsByCategory } from "app/_apis/events/category";
+import { queryOptions } from "@tanstack/react-query";
 
 export const useCategoryEvents = (
   category: string,
@@ -14,6 +15,13 @@ export const useCategoryEvents = (
     ...options, // enabled 등 외부 옵션 허용
   });
 };
+
+export const categoryEventsQueryOptions = (category: string) =>
+  queryOptions({
+    queryKey: ["category-events-home", category],
+    queryFn: () => getEventsByCategory(category),
+    staleTime: 1000 * 60,
+  });
 
 export const useCategoryPageEvents = (
   category: string,

--- a/src/app/_stores/use-home-store.ts
+++ b/src/app/_stores/use-home-store.ts
@@ -1,9 +1,9 @@
 import { create } from "zustand";
-import { persist, createJSONStorage } from "zustand/middleware";
 import { CATEGORY_LABELS } from "@/constants";
 
 export type HomeTab = "discover" | "recommend";
 export type CategoryLabel = (typeof CATEGORY_LABELS)[number];
+
 export type HomeBackContext = {
   source: "home";
   path: string;
@@ -22,64 +22,41 @@ type HomeUIState = {
   reset: () => void;
   setBackContext: (context: HomeBackContext | null) => void;
   clearBackContext: () => void;
-
-  hasHydrated: boolean;
-  setHasHydrated: (v: boolean) => void;
 };
 
 const DEFAULT_CATEGORY: CategoryLabel = "인기";
 
-export const useHomeUIStore = create<HomeUIState>()(
-  persist(
-    (set, get) => ({
+export const useHomeUIStore = create<HomeUIState>()((set, get) => ({
+  activeTab: "discover",
+  selectedCategory: DEFAULT_CATEGORY,
+  fetchedCategories: ["인기", "최신"],
+  backContext: null,
+
+  setActiveTab: (tab) => set({ activeTab: tab }),
+
+  setSelectedCategory: (label) => {
+    set({ selectedCategory: label });
+    get().ensureFetchedCategory(label);
+  },
+
+  ensureFetchedCategory: (label) => {
+    const { fetchedCategories } = get();
+
+    if (fetchedCategories.includes(label)) {
+      return;
+    }
+
+    set({ fetchedCategories: [...fetchedCategories, label] });
+  },
+
+  reset: () =>
+    set({
       activeTab: "discover",
       selectedCategory: DEFAULT_CATEGORY,
       fetchedCategories: ["인기", "최신"],
       backContext: null,
-
-      setActiveTab: (tab) => set({ activeTab: tab }),
-
-      setSelectedCategory: (label) => {
-        set({ selectedCategory: label });
-        get().ensureFetchedCategory(label);
-      },
-
-      ensureFetchedCategory: (label) => {
-        const { fetchedCategories } = get();
-        if (fetchedCategories.includes(label)) return;
-        set({ fetchedCategories: [...fetchedCategories, label] });
-      },
-
-      reset: () =>
-        set({
-          activeTab: "discover",
-          selectedCategory: DEFAULT_CATEGORY,
-          fetchedCategories: ["인기", "최신"],
-          backContext: null,
-        }),
-
-      setBackContext: (context) => set({ backContext: context }),
-      clearBackContext: () => set({ backContext: null }),
-
-      hasHydrated: false,
-      setHasHydrated: (v) => set({ hasHydrated: v }),
     }),
-    {
-      name: "home-ui-store",
-      storage:
-        typeof window !== "undefined"
-          ? createJSONStorage(() => sessionStorage)
-          : undefined,
-      partialize: (state) => ({
-        activeTab: state.activeTab,
-        selectedCategory: state.selectedCategory,
-        fetchedCategories: state.fetchedCategories,
-        backContext: state.backContext,
-      }),
 
-      onRehydrateStorage: () => (state) => {
-        state?.setHasHydrated(true);
-      },
-    },
-  ),
-);
+  setBackContext: (context) => set({ backContext: context }),
+  clearBackContext: () => set({ backContext: null }),
+}));

--- a/src/app/_types/card.ts
+++ b/src/app/_types/card.ts
@@ -23,5 +23,5 @@ export interface CardProps {
   progressRate?: string;
   estimatedPrice?: number | string;
   query?: Record<string, string>;
-  imagePriority: boolean;
+  imagePriority?: boolean;
 }

--- a/src/app/_types/card.ts
+++ b/src/app/_types/card.ts
@@ -23,4 +23,5 @@ export interface CardProps {
   progressRate?: string;
   estimatedPrice?: number | string;
   query?: Record<string, string>;
+  imagePriority: boolean;
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

홈 화면 LCP 후보 이미지 로딩 경로 개선


## #️⃣ 연관된 이슈

<!-- close #123 -->

close #394

---
## 📋 작업 상세 내용
### 홈 카드 이미지 로딩 우선순위 개선

홈 화면 Lighthouse 측정 결과, FCP와 Speed Index는 비교적 빠르게 측정되었지만 LCP가 상대적으로 높게 측정되었습니다.

LCP 요소를 확인한 결과, 홈 첫 화면에 노출되는 이벤트 카드 이미지가 LCP 후보로 잡히고 있었고, 이미지 다운로드 시간보다 이미지 요청이 시작되기까지의 지연이 더 큰 것으로 확인했습니다.

이에 홈 카드 리스트에서 첫 번째로 노출되는 카드 이미지를 LCP 후보 이미지로 보고, 해당 이미지에만 우선순위를 적용했습니다.

- `Card` 컴포넌트에 `imagePriority` 옵션 추가
- 홈 카드 리스트의 첫 번째 카드에만 `imagePriority` 적용
- LCP 후보 이미지에 `fetchPriority="high"` / `loading="eager"` 적용
- 나머지 카드 이미지는 기존 lazy loading 유지

### 홈 기본 카테고리 데이터 prefetch 추가

기존에는 홈 진입 후 클라이언트에서 카테고리 이벤트 데이터를 요청한 뒤 카드가 렌더링되었습니다.

이 경우 카드 이미지 URL이 클라이언트 데이터 로딩 이후에야 DOM에 반영되기 때문에, LCP 이미지 요청 시작 시점이 늦어질 수 있었습니다.

이를 개선하기 위해 홈 기본 카테고리 데이터를 서버에서 미리 prefetch하고, `HydrationBoundary`를 통해 클라이언트에서 React Query 캐시를 재사용하도록 수정했습니다.

- 홈 기본 카테고리 이벤트 데이터 prefetch 추가
- `dehydrate` / `HydrationBoundary` 적용
- 서버와 클라이언트에서 동일한 query option을 재사용하도록 `category queryOptions` 공용화
- `useCategoryEvents` 훅이 공용 query option을 사용하도록 수정

### 서버 환경 axios baseURL 보정

서버 prefetch 과정에서 기존 axios 설정이 클라이언트의 `/api` proxy 경로에 의존하고 있어 서버 환경에서 API 요청이 정상적으로 처리되지 않는 문제가 있었습니다.

이에 서버와 클라이언트 환경에 따라 axios `baseURL`을 다르게 설정하도록 보정했습니다.

- 클라이언트: 기존 `/api` proxy 경로 유지
- 서버: API origin을 기준으로 절대 URL 요청
- 서버 prefetch 요청 시 인증 쿠키가 필요한 경우를 고려해 요청 헤더 전달 처리

### 홈 상태 관리 로직 정리

홈 탭/카테고리 상태가 sessionStorage에 persist되면서 새로고침 시 서버 prefetch 기본값과 클라이언트 복원 상태가 달라지는 문제가 있었습니다.

이 경우 초기에는 기본 카테고리 데이터가 렌더링된 뒤, hydration 이후 저장된 카테고리로 변경되면서 화면 깜빡임과 재요청이 발생할 수 있었습니다.

뒤로가기 시 이전 홈 상태를 유지하는 목적은 Zustand 메모리 상태만으로도 충분하다고 판단하여, 홈 UI 상태의 persist 로직을 제거했습니다.

- 홈 탭/카테고리 상태 persist 제거
- `hasHydrated` 관련 로직 제거
- 새로고침 시 기본 카테고리 기준으로 초기화
- 상세 페이지 이동 후 뒤로가기 시에는 Zustand 메모리 상태 유지


---

