### PR TITLE
[Bug/#396] prefetch 문제 해결

### DIFF
--- a/src/app/(tabs)/home/_components/discover.tsx
+++ b/src/app/(tabs)/home/_components/discover.tsx
@@ -22,6 +22,8 @@ export default function Discover() {
 
   const events = data?.eventList ?? [];
   const hasData = events.length > 0;
+  const previewEvents = events.slice(0, 5);
+  const shouldShowMoreButton = events.length > 5;
 
   const loadingForGate = isLoading && !data;
 
@@ -78,7 +80,7 @@ export default function Discover() {
         }
       >
         <>
-          {events.slice(0, 5).map((event, index) => (
+          {previewEvents.map((event, index) => (
             <div key={event.eventId}>
               <Card
                 id={String(event.eventId)}
@@ -97,7 +99,7 @@ export default function Discover() {
             </div>
           ))}
 
-          {events.length > 5 && (
+          {shouldShowMoreButton && (
             <Button
               className="mt-5 mb-5 active:bg-gray-900"
               variant="secondary"

--- a/src/app/(tabs)/home/_components/discover.tsx
+++ b/src/app/(tabs)/home/_components/discover.tsx
@@ -32,89 +32,93 @@ export default function Discover() {
   };
 
   return (
-    <section className="flex h-full flex-col overflow-x-hidden px-5 pb-[calc(env(safe-area-inset-bottom)+8px)]">
-      <div className="scrollbar-hide my-5 -mr-4 flex overflow-x-auto whitespace-nowrap">
-        {CATEGORY_LABELS.map((label) => (
-          <div key={label} className="flex items-center">
-            <button
-              type="button"
-              className={`body-3-medium px-2.5 py-3.5 ${
-                selected === label ? "text-red-main" : "text-gray-500"
-              }`}
-              onClick={() => handleCategoryClick(label)}
-            >
-              {label}
-            </button>
-            {label === "최신" && <div className="mx-2 h-4 w-px bg-gray-800" />}
-          </div>
-        ))}
-      </div>
-
-      <SkeletonGate
-        key={selected}
-        loading={loadingForGate}
-        hasData={hasData}
-        showAfterMs={150}
-        minVisibleMs={350}
-        fallback={
-          <div className="mb-26 flex flex-col gap-4">
-            {Array.from({ length: 4 }).map((_, idx) => (
-              <CardSkeleton key={idx} />
-            ))}
-          </div>
-        }
-        empty={
-          <div className="flex flex-1 flex-col items-center justify-center text-center text-gray-500">
-            <EmptyIcon />
-            <p className="body-3-medium mt-3.5 mb-7.5 text-gray-800">
-              아직 모집 이벤트가 없어요 <br />
-              지금 바로 나만의 이벤트를 만들어보세요
-            </p>
-            <Button
-              className="w-60.5 active:bg-gray-900"
-              onClick={() => router.push(`/event-create`)}
-            >
-              나만의 이벤트 만들러 가기
-            </Button>
-          </div>
-        }
-      >
-        <>
-          {previewEvents.map((event, index) => (
-            <div key={event.eventId}>
-              <Card
-                id={String(event.eventId)}
-                imageUrl={event.posterImageUrl}
-                category={event.mediaType}
-                title={event.mediaTitle}
-                placeAndDate={`${event.locationName} · ${event.eventDate}`}
-                description={event.description}
-                ddayBadge={`D-${event.d_day}`}
-                statusBadge={event.eventStatus}
-                progressRate={`${event.rate}%`}
-                estimatedPrice={String(event.estimatedPrice)}
-                imagePriority={index === 0}
-              />
-              <div className="my-4 h-px w-full bg-gray-950" />
+    <section className="flex h-full flex-col overflow-hidden px-5 pb-[calc(env(safe-area-inset-bottom)+8px)]">
+      <div className="shrink-0">
+        <div className="scrollbar-hide my-5 -mr-4 flex overflow-x-auto whitespace-nowrap">
+          {CATEGORY_LABELS.map((label) => (
+            <div key={label} className="flex items-center">
+              <button
+                type="button"
+                className={`body-3-medium px-2.5 py-3.5 ${
+                  selected === label ? "text-red-main" : "text-gray-500"
+                }`}
+                onClick={() => handleCategoryClick(label)}
+              >
+                {label}
+              </button>
+              {label === "최신" && (
+                <div className="mx-2 h-4 w-px bg-gray-800" />
+              )}
             </div>
           ))}
+        </div>
+      </div>
 
-          {shouldShowMoreButton && (
-            <Button
-              className="mt-5 mb-5 active:bg-gray-900"
-              variant="secondary"
-              onClick={() => {
-                const categorySlug = categoryMap[selected];
-                router.push(`/category/${categorySlug}`);
-              }}
-            >
-              더보기
-            </Button>
-          )}
-        </>
-      </SkeletonGate>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <SkeletonGate
+          key={selected}
+          loading={loadingForGate}
+          hasData={hasData}
+          showAfterMs={150}
+          minVisibleMs={350}
+          fallback={
+            <div className="mb-26 flex flex-col gap-4">
+              {Array.from({ length: 4 }).map((_, idx) => (
+                <CardSkeleton key={idx} />
+              ))}
+            </div>
+          }
+          empty={
+            <div className="flex h-full flex-col items-center justify-center text-center text-gray-500">
+              <EmptyIcon />
+              <p className="body-3-medium mt-3.5 mb-7.5 text-gray-800">
+                아직 모집 이벤트가 없어요 <br />
+                지금 바로 나만의 이벤트를 만들어보세요
+              </p>
+              <Button
+                className="w-60.5 active:bg-gray-900"
+                onClick={() => router.push(`/event-create`)}
+              >
+                나만의 이벤트 만들러 가기
+              </Button>
+            </div>
+          }
+        >
+          <>
+            {previewEvents.map((event, index) => (
+              <div key={event.eventId}>
+                <Card
+                  id={String(event.eventId)}
+                  imageUrl={event.posterImageUrl}
+                  category={event.mediaType}
+                  title={event.mediaTitle}
+                  placeAndDate={`${event.locationName} · ${event.eventDate}`}
+                  description={event.description}
+                  ddayBadge={`D-${event.d_day}`}
+                  statusBadge={event.eventStatus}
+                  progressRate={`${event.rate}%`}
+                  estimatedPrice={String(event.estimatedPrice)}
+                  imagePriority={index === 0}
+                />
+                <div className="my-4 h-px w-full bg-gray-950" />
+              </div>
+            ))}
 
-      <div className="h-px shrink-0 snap-end" aria-hidden />
+            {shouldShowMoreButton && (
+              <Button
+                className="mt-5 mb-5 active:bg-gray-900"
+                variant="secondary"
+                onClick={() => {
+                  const categorySlug = categoryMap[selected];
+                  router.push(`/category/${categorySlug}`);
+                }}
+              >
+                더보기
+              </Button>
+            )}
+          </>
+        </SkeletonGate>
+      </div>
     </section>
   );
 }

--- a/src/app/(tabs)/home/_components/discover.tsx
+++ b/src/app/(tabs)/home/_components/discover.tsx
@@ -39,6 +39,7 @@ export default function Discover() {
             <div key={label} className="flex items-center">
               <button
                 type="button"
+                aria-pressed={selected === label}
                 className={`body-3-medium px-2.5 py-3.5 ${
                   selected === label ? "text-red-main" : "text-gray-500"
                 }`}

--- a/src/app/(tabs)/home/_utils/category-events.ts
+++ b/src/app/(tabs)/home/_utils/category-events.ts
@@ -3,28 +3,60 @@ import "server-only";
 import type { QueryClient } from "@tanstack/react-query";
 
 import { categoryEventsQueryOptions } from "app/_hooks/events/use-category-events";
-import { getForwardedCookieHeader } from "app/_apis/server-cookie";
+import {
+  getForwardedCookieHeader,
+  getRequestCookieNames,
+} from "app/_apis/server-cookie";
+
+type CategoryEventsResponse = {
+  eventList?: unknown[];
+};
 
 export const prefetchHomeCategoryEvents = async (
   queryClient: QueryClient,
   category: string,
 ) => {
+  let cookieHeader = "";
+  let requestCookieNames: string[] = [];
+
   try {
-    const cookieHeader = await getForwardedCookieHeader();
-    await queryClient.prefetchQuery(
-      categoryEventsQueryOptions(
-        category,
-        cookieHeader
-          ? {
-              headers: {
-                Cookie: cookieHeader,
-              },
-            }
-          : undefined,
-      ),
+    requestCookieNames = await getRequestCookieNames();
+    cookieHeader = await getForwardedCookieHeader({ forwardAll: true });
+
+    const queryOption = categoryEventsQueryOptions(
+      category,
+      cookieHeader
+        ? {
+            headers: {
+              Cookie: cookieHeader,
+            },
+          }
+        : undefined,
+      { strict: true },
     );
+
+    await queryClient.prefetchQuery(queryOption);
+
+    const prefetchedData = queryClient.getQueryData<CategoryEventsResponse>(
+      queryOption.queryKey,
+    );
+
+    console.log("홈 카테고리 prefetch 성공", {
+      category,
+      hasCookie: Boolean(cookieHeader),
+      requestCookieNames,
+      hasData: Boolean(prefetchedData),
+      eventListLength: prefetchedData?.eventList?.length ?? 0,
+      dataKeys: prefetchedData ? Object.keys(prefetchedData) : [],
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : "unknown error";
-    console.error("홈 카테고리 이벤트 prefetch 실패", { category, message });
+
+    console.error("홈 카테고리 prefetch 실패", {
+      category,
+      hasCookie: Boolean(cookieHeader),
+      requestCookieNames,
+      message,
+    });
   }
 };

--- a/src/app/(tabs)/home/_utils/category-events.ts
+++ b/src/app/(tabs)/home/_utils/category-events.ts
@@ -35,11 +35,7 @@ export const prefetchHomeCategoryEvents = async (
       { strict: true },
     );
 
-    await queryClient.prefetchQuery(queryOption);
-
-    const prefetchedData = queryClient.getQueryData<CategoryEventsResponse>(
-      queryOption.queryKey,
-    );
+    const prefetchedData = await queryClient.fetchQuery(queryOption);
 
     console.log("홈 카테고리 prefetch 성공", {
       category,

--- a/src/app/_apis/events/category.ts
+++ b/src/app/_apis/events/category.ts
@@ -7,6 +7,33 @@ interface CategoryEventsResult {
   totalPages: number;
   eventList: EventCard[];
 }
+
+const normalizeCategoryEvents = (
+  res: Partial<CategoryEventsResult> | undefined,
+): CategoryEventsResult => ({
+  totalPages: res?.totalPages ?? 0,
+  eventList: res?.eventList ?? [],
+});
+
+export const fetchEventsByCategory = async (
+  category: string,
+  page = 0,
+  size = 10,
+  config?: AxiosRequestConfig,
+): Promise<CategoryEventsResult> => {
+  const res = await apiGet<CategoryEventsResult>(
+    "/events/category",
+    {
+      category,
+      page,
+      size,
+    },
+    config,
+  );
+
+  return normalizeCategoryEvents(res);
+};
+
 export const getEventsByCategory = async (
   category: string,
   page = 0,
@@ -14,20 +41,7 @@ export const getEventsByCategory = async (
   config?: AxiosRequestConfig,
 ): Promise<CategoryEventsResult> => {
   try {
-    const res = await apiGet<CategoryEventsResult>(
-      "/events/category",
-      {
-        category,
-        page,
-        size,
-      },
-      config,
-    );
-
-    return {
-      totalPages: res.totalPages ?? 0,
-      eventList: res.eventList ?? [],
-    };
+    return await fetchEventsByCategory(category, page, size, config);
   } catch (error) {
     devError("카테고리 이벤트 요청 실패:", error);
     return {

--- a/src/app/_apis/server-cookie.ts
+++ b/src/app/_apis/server-cookie.ts
@@ -4,10 +4,20 @@ import { cookies } from "next/headers";
 
 const DEFAULT_FORWARDED_COOKIE_NAMES = ["accessToken"] as const;
 
+type ForwardedCookieHeaderOptions = {
+  cookieNames?: readonly string[];
+  forwardAll?: boolean;
+};
+
 export const getForwardedCookieHeader = async (
-  cookieNames: readonly string[] = DEFAULT_FORWARDED_COOKIE_NAMES,
+  options?: ForwardedCookieHeaderOptions,
 ) => {
   const cookieStore = await cookies();
+  const cookieNames = options?.cookieNames ?? DEFAULT_FORWARDED_COOKIE_NAMES;
+
+  if (options?.forwardAll) {
+    return cookieStore.toString();
+  }
 
   return cookieNames
     .map((name) => {
@@ -17,4 +27,9 @@ export const getForwardedCookieHeader = async (
     })
     .filter((value): value is string => Boolean(value))
     .join("; ");
+};
+
+export const getRequestCookieNames = async () => {
+  const cookieStore = await cookies();
+  return cookieStore.getAll().map((cookie) => cookie.name);
 };

--- a/src/app/_hooks/events/use-category-events.ts
+++ b/src/app/_hooks/events/use-category-events.ts
@@ -1,14 +1,26 @@
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import type { AxiosRequestConfig } from "axios";
-import { getEventsByCategory } from "app/_apis/events/category";
+import {
+  fetchEventsByCategory,
+  getEventsByCategory,
+} from "app/_apis/events/category";
+
+export const categoryEventsQueryKey = (category: string) =>
+  ["category-events", category] as const;
 
 export const categoryEventsQueryOptions = (
   category: string,
   config?: AxiosRequestConfig,
+  options?: {
+    strict?: boolean;
+  },
 ) =>
   queryOptions({
-    queryKey: ["category-events", category],
-    queryFn: () => getEventsByCategory(category, 0, 10, config),
+    queryKey: categoryEventsQueryKey(category),
+    queryFn: () =>
+      options?.strict
+        ? fetchEventsByCategory(category, 0, 10, config)
+        : getEventsByCategory(category, 0, 10, config),
     staleTime: 1000 * 60,
   });
 
@@ -20,7 +32,7 @@ export const useCategoryEvents = (
 ) => {
   return useQuery({
     ...categoryEventsQueryOptions(category),
-    ...options, // enabled 등 외부 옵션 허용
+    enabled: Boolean(category) && (options?.enabled ?? true),
   });
 };
 
@@ -30,8 +42,9 @@ export const useCategoryPageEvents = (
   size: number = 10,
 ) => {
   return useQuery({
-    queryKey: ["category-page-events", category, page],
+    queryKey: ["category-page-events", category, page, size],
     queryFn: () => getEventsByCategory(category, page, size),
     staleTime: 1000 * 60 * 5,
+    enabled: Boolean(category),
   });
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안


## #️⃣ 연관된 이슈

<!-- close #123 -->

close #396 

---
## 📋 작업 상세 내용

홈 서버 prefetch가 제대로 동작하지 않던 문제를 개선했습니다.

- 서버 prefetch 시 쿠키 전달 방식 개선 (`forwardAll` 지원)
- category 조회 로직 정리 (strict 조회 / fallback 조회 분리)
- React Query key/options 정리로 prefetch 캐시 일관성 개선
- 홈 `Discover` 렌더링 코드 일부 가독성 개선
---

